### PR TITLE
Basic hardening

### DIFF
--- a/build_hardened.sh
+++ b/build_hardened.sh
@@ -1,0 +1,6 @@
+## Simple dirty script for compiling dnscap with
+## SECCOMP-BPF and some compiler hardening flags
+
+gcc -Wall -g -O2  -c dnscap.c -DSECCOMP=1
+gcc -Wall -g -O2  -c dump_dns.c -DSECCOMP=1
+gcc -o dnscap  dnscap.o dump_dns.o  -ldl -lpcap -lresolv -lseccomp -fPIE -fstack-protector-all -Wl,-z,relro -Wformat -Wformat-security -Werror=format-security -D_FORTIFY_SOURCE=2


### PR DESCRIPTION
This patch from Yahoo Paranoids will add some basic hardening to dnscap. With this patch applied dnscap will drop privileges to the 'nobody' user by default.

If SECCOMP is defined and -y is used a very weak seccomp-bpf sandbox will be enabled. Unfortunately the sandbox enables read/write/open due to pcap requirements.

The build_hardened.sh script will compile dnscap (after running ./configure) with SECCOMP support and a few other compiler flags for hardening the final dnscap binary.